### PR TITLE
📚 docs: add API-ENDPOINTS.md and fix ENTITY-TYPES.md inaccuracies

### DIFF
--- a/WORKFLOW-SUMMARY.md
+++ b/WORKFLOW-SUMMARY.md
@@ -80,7 +80,8 @@ release.yml workflow triggers
 | **GITHUB-ACTIONS-GUIDE.md** | Workflow reference | DevOps/Maintainers |
 | **AUTOMATIC-PUBLISHING.md** | Publishing workflow | Maintainers/Release managers |
 | **TESTING.md** | Test suite & verification | QA/Developers |
-| **ENTITY-TYPES.md** | Type schemas | API users |
+| **ENTITY-TYPES.md** | Type schemas with real API shapes | API users |
+| **API-ENDPOINTS.md** | Raw endpoint reference & response shapes | API users/Developers |
 | **OUTPUT-FORMATS.md** | Field reference | Users |
 | **OUTPUT-EXAMPLES.md** | Usage examples | Users |
 | **NPM-PUBLISHING.md** | Distribution explained | Users |
@@ -340,6 +341,7 @@ huntr-cli/
 │   ├── AUTOMATIC-PUBLISHING.md
 │   ├── TESTING.md
 │   ├── ENTITY-TYPES.md
+│   ├── API-ENDPOINTS.md
 │   ├── OUTPUT-FORMATS.md
 │   ├── OUTPUT-EXAMPLES.md
 │   └── NPM-PUBLISHING.md

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -27,6 +27,7 @@ Returns the authenticated user's profile.
 }
 ```
 
+> **Note:** The TypeScript `UserProfile` type in `src/types/personal.ts` is currently out of sync with this raw `/user` response shape: it requires a `createdAt` field and does not model `fullName` or `auth0IdForMixpanel`. Callers should either adapt the raw response to `UserProfile` or handle the raw shape directly.
 ---
 
 ### `GET /user/boards`

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -113,7 +113,7 @@ Custom user-created lists have `stageType: null`.
 
 ### `GET /board/:boardId/jobs`
 
-Returns all jobs for a board as an **object map** keyed by job ID.
+Returns a wrapper object with a `jobs` property containing all jobs for a board as an **object map** keyed by job ID (i.e. `{ "jobs": { "<jobId>": Job } }`).
 
 **Response:**
 ```json

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -32,14 +32,14 @@ Returns the authenticated user's profile.
 
 ### `GET /user/boards`
 
-Returns all boards for the authenticated user. The raw backend for this endpoint may return different shapes, so callers **must not** rely on a single raw response shape. `huntr-cli` normalizes all variants into a **`Board[]` array** (see `PersonalBoardsApi.list()` in `src/api/personal/boards.ts`).
+Returns all boards for the authenticated user. The raw backend for this endpoint may return different shapes; `huntr-cli` normalizes all variants into a **`Board[]` array** before returning to callers.
 
-Observed raw response variants (before normalization):
+Observed raw response variants:
 - An array of board objects: `[ { ...board }, { ...board }, ... ]`.
 - An object with a `data` property containing an array: `{ "data": [ { ...board }, ... ] }`.
-- An object map keyed by board ID: `{ "<boardId>": { ...board }, ... }`.
+- An object map keyed by board ID: `{ "<boardId>": { ...board }, ... }` (callers should not rely on this shape directly).
 
-**Normalized response shape returned by `huntr-cli` callers (`Board[]`):**
+**Normalized response shape returned by `huntr-cli` (`Board[]`):**
 ```json
 [
   {

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -168,32 +168,31 @@ Returns a single job object (same shape as above, unwrapped from the `jobs` map)
 
 ### `GET /board/:boardId/actions`
 
-Returns activity log for a board as an **object map** keyed by action ID, plus a `nextPage` cursor for pagination.
+Returns activity log for a board as a **plain object map** keyed by action ID (no wrapper object).
+
+> **Note:** huntr-cli consumes this response directly as `Record<string, PersonalAction>` — it does not expect an `{ actions: {…}, nextPage }` envelope. If the live API ever returns a wrapper shape, `PersonalActionsApi.listByBoard()` would need to be updated accordingly.
 
 **Response:**
 ```json
 {
-  "actions": {
-    "<actionId>": {
-      "_id": "...",
-      "id": "...",
-      "actionType": "JOB_MOVED",
-      "date": "2026-01-04T18:49:34.240Z",
-      "createdAt": "2026-01-04T18:49:34.240Z",
-      "data": {
-        "_job": "<jobId>",
-        "_company": "<companyId>",
-        "_board": "<boardId>",
-        "_fromList": "<listId>",
-        "_toList": "<listId>",
-        "job": { "_id": "...", "id": "...", "title": "Software Architect" },
-        "company": { "_id": "...", "id": "...", "name": "Viasat", "color": null },
-        "fromList": { "_id": "...", "id": "...", "name": "wishlist" },
-        "toList": { "_id": "...", "id": "...", "name": "applied" }
-      }
+  "<actionId>": {
+    "_id": "...",
+    "id": "...",
+    "actionType": "JOB_MOVED",
+    "date": "2026-01-04T18:49:34.240Z",
+    "createdAt": "2026-01-04T18:49:34.240Z",
+    "data": {
+      "_job": "<jobId>",
+      "_company": "<companyId>",
+      "_board": "<boardId>",
+      "_fromList": "<listId>",
+      "_toList": "<listId>",
+      "job": { "_id": "...", "id": "...", "title": "Software Architect" },
+      "company": { "_id": "...", "id": "...", "name": "Viasat", "color": null },
+      "fromList": { "_id": "...", "id": "...", "name": "wishlist" },
+      "toList": { "_id": "...", "id": "...", "name": "applied" }
     }
-  },
-  "nextPage": null
+  }
 }
 ```
 

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -32,14 +32,14 @@ Returns the authenticated user's profile.
 
 ### `GET /user/boards`
 
-Returns all boards for the authenticated user. The raw backend for this endpoint may return different shapes; `huntr-cli` normalizes them all into a **`Board[]` array** (see `PersonalBoardsApi.list()` in `src/api/personal/boards.ts`).
+Returns all boards for the authenticated user. The raw backend for this endpoint may return different shapes, so callers **must not** rely on a single raw response shape. `huntr-cli` normalizes all variants into a **`Board[]` array** (see `PersonalBoardsApi.list()` in `src/api/personal/boards.ts`).
 
 Observed raw response variants (before normalization):
 - An array of board objects: `[ { ...board }, { ...board }, ... ]`.
-- An object with a `data` property containing an array of boards: `{ "data": [ { ...board }, ... ] }`.
+- An object with a `data` property containing an array: `{ "data": [ { ...board }, ... ] }`.
 - An object map keyed by board ID: `{ "<boardId>": { ...board }, ... }`.
 
-**Normalized response shape returned by `PersonalBoardsApi.list()` (a `Board[]` array):**
+**Normalized response shape returned by `huntr-cli` callers (`Board[]`):**
 ```json
 [
   {

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -4,7 +4,7 @@ This document captures the actual raw API endpoints used by huntr-cli, their res
 
 ## Authentication
 
-All requests use a `Authorization: Bearer <token>` header. Tokens are short-lived JWTs obtained via Clerk session refresh. See `src/config/clerk-session-manager.ts`.
+All requests use an `Authorization: Bearer <token>` header. Tokens are short-lived JWTs obtained via Clerk session refresh. See `src/config/clerk-session-manager.ts`.
 
 ---
 
@@ -17,13 +17,13 @@ Returns the authenticated user's profile.
 **Response:**
 ```json
 {
-  "_id": "66688215168bb20075e89571",
+  "_id": "<userId>",
   "email": "user@example.com",
-  "givenName": "Matthew",
-  "familyName": "McKnight",
-  "fullName": "Matthew McKnight",
-  "auth0IdForMixpanel": "66688215168bb20075e89571",
-  "id": "66688215168bb20075e89571"
+  "givenName": "<givenName>",
+  "familyName": "<familyName>",
+  "fullName": "<fullName>",
+  "auth0IdForMixpanel": "<userId>",
+  "id": "<userId>"
 }
 ```
 
@@ -41,24 +41,24 @@ Returns all boards for the authenticated user as an **object map** keyed by boar
     "_members": [],
     "_invitations": [],
     "_lists": [
-      "68bf9e33f871e5004a5eb592",
-      "68bf9e33f871e5004a5eb593"
+      "<listId1>",
+      "<listId2>"
     ],
-    "_id": "68bf9e33f871e5004a5eb58e",
+    "_id": "<boardId>",
     "_user": {
-      "_id": "66688215168bb20075e89571",
+      "_id": "<userId>",
       "email": "user@example.com",
-      "givenName": "Matthew",
-      "familyName": "McKnight",
-      "fullName": "Matthew McKnight",
-      "id": "66688215168bb20075e89571"
+      "givenName": "<givenName>",
+      "familyName": "<familyName>",
+      "fullName": "<fullName>",
+      "id": "<userId>"
     },
     "name": "Job Search 2025",
     "createdAt": "2025-09-09T03:25:39.770Z",
     "updatedAt": "2026-01-22T18:23:46.492Z",
     "__v": 8,
     "organization": null,
-    "id": "68bf9e33f871e5004a5eb58e"
+    "id": "<boardId>"
   }
 }
 ```
@@ -75,16 +75,16 @@ Returns all lists for a board as an **object map** keyed by list ID. This is the
 ```json
 {
   "<listId>": {
-    "_id": "68bf9e33f871e5004a5eb593",
+    "_id": "<listId>",
     "name": "applied",
-    "_board": "68bf9e33f871e5004a5eb58e",
+    "_board": "<boardId>",
     "_jobs": ["<jobId>", "..."],
     "stageType": "APPLY",
     "suggestedActivityCategoryNames": ["Follow Up", "Reach Out"],
     "createdAt": "2025-09-09T03:25:39.779Z",
     "updatedAt": "2026-03-06T22:36:02.131Z",
     "__v": 0,
-    "id": "68bf9e33f871e5004a5eb593"
+    "id": "<listId>"
   }
 }
 ```
@@ -114,19 +114,19 @@ Returns all jobs for a board as an **object map** keyed by job ID.
 {
   "jobs": {
     "<jobId>": {
-      "_id": "695ab63801de6a0051c0b03c",
-      "id": "695ab63801de6a0051c0b03c",
+      "_id": "<jobId>",
+      "id": "<jobId>",
       "title": "Software Architect",
       "url": "https://...",
       "rootDomain": "icims.com",
       "htmlDescription": "<p>...</p>",
       "titleBaseKeyword": "Software Architect",
-      "_company": "58bf62e1e281d9000c2a5cb8",
-      "_list": "68bf9e33f871e5004a5eb593",
-      "_board": "68bf9e33f871e5004a5eb58e",
-      "_creatorUser": "66688215168bb20075e89571",
-      "_ownerUser": "66688215168bb20075e89571",
-      "_activities": ["695ab63e36ff3901e24c45f0"],
+      "_company": "<companyId>",
+      "_list": "<listId>",
+      "_board": "<boardId>",
+      "_creatorUser": "<userId>",
+      "_ownerUser": "<userId>",
+      "_activities": ["<activityId>"],
       "_interviewActivities": [],
       "_contacts": [],
       "_todos": [],

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -32,17 +32,17 @@ Returns the authenticated user's profile.
 
 ### `GET /user/boards`
 
-Returns all boards for the authenticated user. The raw backend for this endpoint may return different shapes, so callers **must not** rely on a single raw response shape and should normalize the result into an **object map** keyed by board ID (as `huntr-cli` does).
+Returns all boards for the authenticated user. The raw backend for this endpoint may return different shapes; `huntr-cli` normalizes them all into a **`Board[]` array** (see `PersonalBoardsApi.list()` in `src/api/personal/boards.ts`).
 
-Observed raw response variants:
-- An object map keyed by board ID (see normalized shape below).
+Observed raw response variants (before normalization):
 - An array of board objects: `[ { ...board }, { ...board }, ... ]`.
 - An object with a `data` property containing an array of boards: `{ "data": [ { ...board }, ... ] }`.
+- An object map keyed by board ID: `{ "<boardId>": { ...board }, ... }`.
 
-**Normalized response shape (recommended for callers):**
+**Normalized response shape returned by `PersonalBoardsApi.list()` (a `Board[]` array):**
 ```json
-{
-  "<boardId>": {
+[
+  {
     "isArchived": false,
     "_members": [],
     "_invitations": [],
@@ -66,7 +66,7 @@ Observed raw response variants:
     "organization": null,
     "id": "<boardId>"
   }
-}
+]
 ```
 
 > **Note:** `_lists` contains only list IDs, not list objects. To get list names, use `GET /board/:id/lists`.

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -1,0 +1,209 @@
+# API Endpoints Reference
+
+This document captures the actual raw API endpoints used by huntr-cli, their response shapes, and known limitations. All endpoints are relative to `https://api.huntr.co/api` and require a Bearer token.
+
+## Authentication
+
+All requests use a `Authorization: Bearer <token>` header. Tokens are short-lived JWTs obtained via Clerk session refresh. See `src/config/clerk-session-manager.ts`.
+
+---
+
+## Endpoints
+
+### `GET /user/me`
+
+Returns the authenticated user's profile.
+
+**Response:**
+```json
+{
+  "_id": "66688215168bb20075e89571",
+  "email": "user@example.com",
+  "givenName": "Matthew",
+  "familyName": "McKnight",
+  "fullName": "Matthew McKnight",
+  "auth0IdForMixpanel": "66688215168bb20075e89571",
+  "id": "66688215168bb20075e89571"
+}
+```
+
+---
+
+### `GET /user/boards`
+
+Returns all boards for the authenticated user as an **object map** keyed by board ID.
+
+**Response:**
+```json
+{
+  "<boardId>": {
+    "isArchived": false,
+    "_members": [],
+    "_invitations": [],
+    "_lists": [
+      "68bf9e33f871e5004a5eb592",
+      "68bf9e33f871e5004a5eb593"
+    ],
+    "_id": "68bf9e33f871e5004a5eb58e",
+    "_user": {
+      "_id": "66688215168bb20075e89571",
+      "email": "user@example.com",
+      "givenName": "Matthew",
+      "familyName": "McKnight",
+      "fullName": "Matthew McKnight",
+      "id": "66688215168bb20075e89571"
+    },
+    "name": "Job Search 2025",
+    "createdAt": "2025-09-09T03:25:39.770Z",
+    "updatedAt": "2026-01-22T18:23:46.492Z",
+    "__v": 8,
+    "organization": null,
+    "id": "68bf9e33f871e5004a5eb58e"
+  }
+}
+```
+
+> **Note:** `_lists` contains only list IDs, not list objects. To get list names, use `GET /board/:id/lists`.
+
+---
+
+### `GET /board/:boardId/lists`
+
+Returns all lists for a board as an **object map** keyed by list ID. This is the only way to get list names — there is no endpoint to fetch a single list by ID.
+
+**Response:**
+```json
+{
+  "<listId>": {
+    "_id": "68bf9e33f871e5004a5eb593",
+    "name": "applied",
+    "_board": "68bf9e33f871e5004a5eb58e",
+    "_jobs": ["<jobId>", "..."],
+    "stageType": "APPLY",
+    "suggestedActivityCategoryNames": ["Follow Up", "Reach Out"],
+    "createdAt": "2025-09-09T03:25:39.779Z",
+    "updatedAt": "2026-03-06T22:36:02.131Z",
+    "__v": 0,
+    "id": "68bf9e33f871e5004a5eb593"
+  }
+}
+```
+
+**Default Huntr list names and `stageType` values:**
+
+| `name`     | `stageType`          |
+|------------|----------------------|
+| `wishlist` | `WISHLIST`           |
+| `applied`  | `APPLY`              |
+| `interview`| `ON_SITE_INTERVIEW`  |
+| `offer`    | `OFFER_RECEIVED`     |
+| `rejected` | `REJECTED`           |
+
+Custom user-created lists have `stageType: null`.
+
+> **No single-list endpoint exists.** `GET /list/:id`, `GET /lists/:id`, and `GET /board/:id/lists/:listId` all return HTML (not API routes).
+
+---
+
+### `GET /board/:boardId/jobs`
+
+Returns all jobs for a board as an **object map** keyed by job ID.
+
+**Response:**
+```json
+{
+  "jobs": {
+    "<jobId>": {
+      "_id": "695ab63801de6a0051c0b03c",
+      "id": "695ab63801de6a0051c0b03c",
+      "title": "Software Architect",
+      "url": "https://...",
+      "rootDomain": "icims.com",
+      "htmlDescription": "<p>...</p>",
+      "titleBaseKeyword": "Software Architect",
+      "_company": "58bf62e1e281d9000c2a5cb8",
+      "_list": "68bf9e33f871e5004a5eb593",
+      "_board": "68bf9e33f871e5004a5eb58e",
+      "_creatorUser": "66688215168bb20075e89571",
+      "_ownerUser": "66688215168bb20075e89571",
+      "_activities": ["695ab63e36ff3901e24c45f0"],
+      "_interviewActivities": [],
+      "_contacts": [],
+      "_todos": [],
+      "_notes": [],
+      "salary": "$161,000.00 - $255,000.00",
+      "location": {
+        "address": "Germantown, MD, USA",
+        "name": "Germantown",
+        "placeId": "ChIJ...",
+        "url": "https://maps.google.com/?cid=...",
+        "lat": "39.1731621",
+        "lng": "-77.2716502"
+      },
+      "createdAt": "2026-01-04T18:49:28.657Z",
+      "updatedAt": "2026-01-08T21:38:00.838Z",
+      "lastMovedAt": "2026-01-04T18:49:34.240Z",
+      "__v": 0
+    }
+  }
+}
+```
+
+**Known shape quirks:**
+- `salary` comes back as a **raw string** (e.g. `"$161,000.00 - $255,000.00"`), not a structured `{ min, max, currency }` object. The TypeScript type `PersonalJob.salary` currently models it as a structured object, which is inaccurate.
+- `_list` is a bare ID — list name must be resolved via `GET /board/:id/lists`.
+
+---
+
+### `GET /board/:boardId/jobs/:jobId`
+
+Returns a single job object (same shape as above, unwrapped from the `jobs` map).
+
+---
+
+### `GET /board/:boardId/actions`
+
+Returns activity log for a board as an **object map** keyed by action ID, plus a `nextPage` cursor for pagination.
+
+**Response:**
+```json
+{
+  "actions": {
+    "<actionId>": {
+      "_id": "...",
+      "id": "...",
+      "actionType": "JOB_MOVED",
+      "date": "2026-01-04T18:49:34.240Z",
+      "createdAt": "2026-01-04T18:49:34.240Z",
+      "data": {
+        "_job": "<jobId>",
+        "_company": "<companyId>",
+        "_board": "<boardId>",
+        "_fromList": "<listId>",
+        "_toList": "<listId>",
+        "job": { "_id": "...", "id": "...", "title": "Software Architect" },
+        "company": { "_id": "...", "id": "...", "name": "Viasat", "color": null },
+        "fromList": { "_id": "...", "id": "...", "name": "wishlist" },
+        "toList": { "_id": "...", "id": "...", "name": "applied" }
+      }
+    }
+  },
+  "nextPage": null
+}
+```
+
+---
+
+## Endpoints That Do Not Work
+
+The following paths return an HTML page (the Huntr SPA) rather than JSON. They are not valid API routes:
+
+| Path | Notes |
+|------|-------|
+| `GET /boards` | Returns HTML |
+| `GET /boards/:id` | Returns HTML — used incorrectly in `PersonalBoardsApi.get()` |
+| `GET /board/:id` | Returns HTML |
+| `GET /list/:id` | Returns HTML |
+| `GET /lists/:id` | Returns HTML |
+| `GET /board/:id/list/:listId` | Returns HTML |
+| `GET /board/:id/lists/:listId` | Returns HTML |

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -10,7 +10,7 @@ All requests use an `Authorization: Bearer <token>` header. Tokens are short-liv
 
 ## Endpoints
 
-### `GET /user/me`
+### `GET /user`
 
 Returns the authenticated user's profile.
 

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -168,9 +168,7 @@ Returns a single job object (same shape as above, unwrapped from the `jobs` map)
 
 ### `GET /board/:boardId/actions`
 
-Returns activity log for a board as a **plain object map** keyed by action ID (no wrapper object).
-
-> **Note:** huntr-cli consumes this response directly as `Record<string, PersonalAction>` — it does not expect an `{ actions: {…}, nextPage }` envelope. If the live API ever returns a wrapper shape, `PersonalActionsApi.listByBoard()` would need to be updated accordingly.
+Returns activity log for a board as a **plain object map** keyed by action ID (no wrapper, no pagination cursor).
 
 **Response:**
 ```json
@@ -195,6 +193,8 @@ Returns activity log for a board as a **plain object map** keyed by action ID (n
   }
 }
 ```
+
+> **Note:** The response is a flat map with no `actions` wrapper and no `nextPage` cursor. Each key is an action ID and the value is the full action object.
 
 ---
 

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -31,14 +31,14 @@ Returns the authenticated user's profile.
 
 ### `GET /user/boards`
 
-Returns all boards for the authenticated user. The raw backend has historically returned multiple shapes for this endpoint, and `huntr-cli` normalizes them into an **object map** keyed by board ID.
+Returns all boards for the authenticated user. The raw backend for this endpoint may return different shapes, so callers **must not** rely on a single raw response shape and should normalize the result into an **object map** keyed by board ID (as `huntr-cli` does).
 
 Observed raw response variants:
 - An object map keyed by board ID (see normalized shape below).
 - An array of board objects: `[ { ...board }, { ...board }, ... ]`.
 - An object with a `data` property containing an array of boards: `{ "data": [ { ...board }, ... ] }`.
 
-**Normalized response (as seen by huntr-cli callers):**
+**Normalized response shape (recommended for callers):**
 ```json
 {
   "<boardId>": {

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -31,9 +31,14 @@ Returns the authenticated user's profile.
 
 ### `GET /user/boards`
 
-Returns all boards for the authenticated user as an **object map** keyed by board ID.
+Returns all boards for the authenticated user. The raw backend has historically returned multiple shapes for this endpoint, and `huntr-cli` normalizes them into an **object map** keyed by board ID.
 
-**Response:**
+Observed raw response variants:
+- An object map keyed by board ID (see normalized shape below).
+- An array of board objects: `[ { ...board }, { ...board }, ... ]`.
+- An object with a `data` property containing an array of boards: `{ "data": [ { ...board }, ... ] }`.
+
+**Normalized response (as seen by huntr-cli callers):**
 ```json
 {
   "<boardId>": {

--- a/docs/API-ENDPOINTS.md
+++ b/docs/API-ENDPOINTS.md
@@ -22,7 +22,7 @@ Returns the authenticated user's profile.
   "givenName": "<givenName>",
   "familyName": "<familyName>",
   "fullName": "<fullName>",
-  "auth0IdForMixpanel": "<userId>",
+  "auth0IdForMixpanel": "<auth0IdForMixpanel>",
   "id": "<userId>"
 }
 ```

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -460,5 +460,6 @@ huntr activities list <board-id> --json | jq '.[] | {date: .date, company: .comp
 
 ## See Also
 
+- [API Endpoints](./API-ENDPOINTS.md) — Raw endpoint shapes, response structures, and non-working routes
 - [Output Formats](./OUTPUT-FORMATS.md) — How fields are displayed in different formats
 - [Output Examples](./OUTPUT-EXAMPLES.md) — Practical usage examples

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -128,10 +128,6 @@ This document shows the complete structure of each entity type returned by huntr
 > `lists: BoardList[]` / `order` shape and have not yet been updated to this `_lists`-based
 > API. See the comments in `src/types/personal.ts` and the associated tracking issue for
 > progress on aligning the generated types with this documented response.
-> **Note:** The current TypeScript definitions in `src/types/personal.ts` still model the legacy
-> `lists: BoardList[]` / `order` shape and have not yet been updated to this `_lists`-based
-> API. See the comments in `src/types/personal.ts` and the associated tracking issue for
-> progress on aligning the generated types with this documented response.
 
 ### BoardList
 
@@ -174,7 +170,7 @@ Returned by `GET /board/:id/lists` as an object map keyed by list ID.
 
 > **Note:** `salary` is returned as a raw string by the API (e.g. `"$161,000.00 - $255,000.00"`). The TypeScript type `PersonalJob.salary` currently models it as a structured object — this is inaccurate and tracked in [issue #20](https://github.com/mattmck/huntr-cli/issues/20).
 >
-> **Warning:** The CLI currently dereferences `job.salary.min`, `job.salary.max`, and `job.salary.currency` in [`src/cli.ts`](../src/cli.ts), so runtime behavior does not match the API's raw salary string. Until the API/type mismatch is normalized, either parse the raw salary string in the CLI or avoid nested salary property access.
+> **Warning:** The CLI currently dereferences `job.salary.min`, `job.salary.max`, and `job.salary.currency` in [`src/cli.ts`](../src/cli.ts). Because the API returns `salary` as a raw string, this can throw at runtime when that code path executes. Mitigate by changing `PersonalJob.salary` to `string` (or `string | undefined`) and parsing explicitly, or by guarding/null-checking before nested property access until the API/type model is normalized.
 
 ### Location
 
@@ -282,7 +278,6 @@ huntr me --json | jq 'keys'
 ### Board (from `GET /user/boards`)
 
 > Note: The `huntr boards get` CLI command currently hits a legacy, non-JSON route whose output still uses a `lists` field instead of `_lists`. The structure below reflects the canonical API shape returned by `GET /user/boards`; the CLI command will be updated to match this schema.
-> **Note:** The `huntr boards get` CLI command currently hits a legacy, non-JSON route whose output still uses a `lists` field instead of `_lists`. The structure below reflects the canonical API shape returned by `GET /user/boards`; the CLI command will be updated to match this schema.
 
 ```json
 {

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -25,27 +25,32 @@ This document shows the complete structure of each entity type returned by huntr
 
 ```typescript
 {
-  _id: "507f1f77bcf86cd799439011",
-  id: "job_001",
-  title: "Senior Engineer at TechCorp",
-  url: "https://techs.jobs/engineer",
-  rootDomain: "techs.jobs",
-  htmlDescription: "HTML job description...",
-  _company: "company_id_ref",
-  _list: "list_id_ref",
-  _board: "board_id_ref",
-  _activities: ["action_1", "action_2"],
-  _notes: ["note_1"],
+  _id: "<jobId>",
+  id: "<jobId>",
+  title: "Software Architect",
+  url: "https://...",
+  rootDomain: "icims.com",
+  htmlDescription: "<p>...</p>",
+  _company: "<companyId>",
+  _list: "<listId>",
+  _board: "<boardId>",
+  _activities: ["<activityId>"],
+  _interviewActivities: [],
+  _contacts: [],
+  _todos: [],
+  _notes: [],
   salary: "$161,000.00 - $255,000.00",  // raw string, not a structured object
   location: {
-    address: "San Francisco, CA",
-    name: "San Francisco",
-    lat: "37.7749",
-    lng: "-122.4194"
+    address: "Germantown, MD, USA",
+    name: "Germantown",
+    placeId: "ChIJ...",
+    url: "https://maps.google.com/?cid=...",
+    lat: "39.1731621",
+    lng: "-77.2716502"
   },
-  createdAt: "2024-01-20T14:15:00Z",
-  updatedAt: "2024-02-15T10:00:00Z",
-  lastMovedAt: "2024-02-18T09:30:00Z"
+  createdAt: "2026-01-04T18:49:28.657Z",
+  updatedAt: "2026-01-08T21:38:00.838Z",
+  lastMovedAt: "2026-01-04T18:49:34.000Z"
 }
 ```
 
@@ -159,6 +164,9 @@ Returned by `GET /board/:id/lists` as an object map keyed by list ID.
 | `_list` | string? | Current list ID (reference) |
 | `_board` | string | Board ID (reference) |
 | `_activities` | string[] | Activity IDs (references) |
+| `_interviewActivities` | string[] | Interview activity IDs (references) |
+| `_contacts` | string[] | Contact IDs (references) |
+| `_todos` | string[] | Todo IDs (references) |
 | `_notes` | string[] | Note IDs (references) |
 | `salary` | string? | Salary as raw string (e.g. `"$120,000 - $150,000"`); **not** a structured object |
 | `location` | Location? | Job location |
@@ -177,10 +185,11 @@ Returned by `GET /board/:id/lists` as an object map keyed by list ID.
 | Field | Type | Description |
 |-------|------|-------------|
 | `address` | string? | Full address |
-| `name` | string? | Location name (e.g., "San Francisco") |
+| `name` | string? | Location name (e.g., "Germantown") |
+| `placeId` | string? | Google Maps place ID (e.g., `"ChIJ..."`) |
+| `url` | string? | Google Maps URL (e.g., `"https://maps.google.com/?cid=..."`) |
 | `lat` | string? | Latitude as string |
 | `lng` | string? | Longitude as string |
-| `url` | string? | Location info URL |
 
 ### Activity (Action)
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -123,6 +123,10 @@ This document shows the complete structure of each entity type returned by huntr
 | `_lists` | string[] | Array of bare list IDs — resolve via `GET /board/:id/lists` |
 | `isArchived` | boolean | Whether board is archived |
 
+> Note: The current TypeScript definitions in `src/types/personal.ts` still model the legacy
+> `lists: BoardList[]` / `order` shape and have not yet been updated to this `_lists`-based
+> API. See the comments in `src/types/personal.ts` and the associated tracking issue for
+> progress on aligning the generated types with this documented response.
 > **Note:** The current TypeScript definitions in `src/types/personal.ts` still model the legacy
 > `lists: BoardList[]` / `order` shape and have not yet been updated to this `_lists`-based
 > API. See the comments in `src/types/personal.ts` and the associated tracking issue for

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -9,14 +9,14 @@ This document shows the complete structure of each entity type returned by huntr
 ```typescript
 {
   id: "68bf9e33f871e5004a5eb58e",
-  _id: "507f1f77bcf86cd799439011",
-  name: "My Job Search",
-  createdAt: "2024-01-15T10:30:00Z",
-  updatedAt: "2024-02-20T15:45:00Z",
-  lists: [
-    { id: "list_1", _id: "...", name: "Active Leads", order: 1 },
-    { id: "list_2", _id: "...", name: "Interviewing", order: 2 }
-  ]
+  _id: "68bf9e33f871e5004a5eb58e",
+  name: "Job Search 2025",
+  createdAt: "2025-09-09T03:25:39.770Z",
+  updatedAt: "2026-01-22T18:23:46.492Z",
+  _lists: [
+    "68bf9e33f871e5004a5eb592",
+    "68bf9e33f871e5004a5eb593"
+  ]  // bare list IDs — use GET /board/:id/lists to resolve names
 }
 ```
 
@@ -35,11 +35,7 @@ This document shows the complete structure of each entity type returned by huntr
   _board: "board_id_ref",
   _activities: ["action_1", "action_2"],
   _notes: ["note_1"],
-  salary: {
-    min: 120000,
-    max: 150000,
-    currency: "USD"
-  },
+  salary: "$161,000.00 - $255,000.00",  // raw string, not a structured object
   location: {
     address: "San Francisco, CA",
     name: "San Francisco",
@@ -101,14 +97,13 @@ This document shows the complete structure of each entity type returned by huntr
 
 ```typescript
 {
-  id: "user_123",
-  _id: "507f1f77bcf86cd799439011",
-  email: "john@example.com",
-  givenName: "John",
-  familyName: "Doe",
-  firstName: "John",
-  lastName: "Doe",
-  createdAt: "2024-01-15T10:30:00Z"
+  id: "66688215168bb20075e89571",
+  _id: "66688215168bb20075e89571",
+  email: "user@example.com",
+  givenName: "Matthew",
+  familyName: "McKnight",
+  fullName: "Matthew McKnight",
+  auth0IdForMixpanel: "66688215168bb20075e89571"
 }
 ```
 
@@ -121,20 +116,28 @@ This document shows the complete structure of each entity type returned by huntr
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string | Unique board identifier (MongoDB ObjectId as string) |
-| `_id` | string | Alternative ID format |
-| `name` | string | Board name (e.g., "My Job Search") |
+| `_id` | string | Same as `id` |
+| `name` | string | Board name (e.g., "Job Search 2025") |
 | `createdAt` | ISO 8601 | Creation timestamp |
 | `updatedAt` | ISO 8601 | Last update timestamp |
-| `lists` | Array<BoardList> | Lists (columns) on the board |
+| `_lists` | string[] | Array of bare list IDs — resolve via `GET /board/:id/lists` |
+| `isArchived` | boolean | Whether board is archived |
 
 ### BoardList
+
+Returned by `GET /board/:id/lists` as an object map keyed by list ID.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string | Unique list identifier |
-| `_id` | string | Alternative ID format |
-| `name` | string | List name (e.g., "Active Leads", "Interviewing") |
-| `order` | number? | Position order on board |
+| `_id` | string | Same as `id` |
+| `name` | string | List name (e.g., `wishlist`, `applied`, `interview`, `offer`, `rejected`) |
+| `_board` | string | Parent board ID |
+| `_jobs` | string[] | Array of job IDs in this list |
+| `stageType` | string\|null | Pipeline stage (`WISHLIST`, `APPLY`, `ON_SITE_INTERVIEW`, `OFFER_RECEIVED`, `REJECTED`); `null` for custom lists |
+| `suggestedActivityCategoryNames` | string[] | Suggested follow-up activity types |
+| `createdAt` | ISO 8601 | Creation timestamp |
+| `updatedAt` | ISO 8601 | Last update timestamp |
 
 ### Job
 
@@ -151,7 +154,7 @@ This document shows the complete structure of each entity type returned by huntr
 | `_board` | string | Board ID (reference) |
 | `_activities` | string[] | Activity IDs (references) |
 | `_notes` | string[] | Note IDs (references) |
-| `salary` | Salary? | Salary information |
+| `salary` | string? | Salary as raw string (e.g. `"$120,000 - $150,000"`); **not** a structured object |
 | `location` | Location? | Job location |
 | `createdAt` | ISO 8601 | When job was added |
 | `updatedAt` | ISO 8601 | Last update |
@@ -159,11 +162,7 @@ This document shows the complete structure of each entity type returned by huntr
 
 ### Salary
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `min` | number? | Minimum salary |
-| `max` | number? | Maximum salary |
-| `currency` | string? | Currency (e.g., "USD", "EUR") |
+> **Note:** `salary` is returned as a raw string by the API (e.g. `"$161,000.00 - $255,000.00"`). The TypeScript type `PersonalJob.salary` currently models it as a structured object — this is inaccurate and tracked in [issue #20](https://github.com/mattmck/huntr-cli/issues/20).
 
 ### Location
 
@@ -210,13 +209,12 @@ This document shows the complete structure of each entity type returned by huntr
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string | Unique user identifier |
-| `_id` | string? | Alternative ID format |
+| `_id` | string | Same as `id` |
 | `email` | string | User email address |
-| `givenName` | string? | First name (from profile) |
-| `familyName` | string? | Last name (from profile) |
-| `firstName` | string? | First name (legacy field) |
-| `lastName` | string? | Last name (legacy field) |
-| `createdAt` | ISO 8601 | Account creation date |
+| `givenName` | string? | First name |
+| `familyName` | string? | Last name |
+| `fullName` | string? | Full name |
+| `auth0IdForMixpanel` | string? | Internal analytics ID |
 
 ---
 
@@ -263,35 +261,37 @@ huntr me --json | jq 'keys'
 
 ## JSON Schema Examples
 
-### Complete Board with Jobs
+### Board (from `GET /user/boards`)
 
 ```json
 {
   "id": "68bf9e33f871e5004a5eb58e",
-  "_id": "507f1f77bcf86cd799439011",
-  "name": "My Job Search",
-  "createdAt": "2024-01-15T10:30:00Z",
-  "updatedAt": "2024-02-20T15:45:00Z",
-  "lists": [
-    {
-      "id": "list_1",
-      "_id": "507f1f77bcf86cd799439012",
-      "name": "Active Leads",
-      "order": 1
-    },
-    {
-      "id": "list_2",
-      "_id": "507f1f77bcf86cd799439013",
-      "name": "Interviewing",
-      "order": 2
-    },
-    {
-      "id": "list_3",
-      "_id": "507f1f77bcf86cd799439014",
-      "name": "Offers",
-      "order": 3
-    }
+  "_id": "68bf9e33f871e5004a5eb58e",
+  "name": "Job Search 2025",
+  "isArchived": false,
+  "createdAt": "2025-09-09T03:25:39.770Z",
+  "updatedAt": "2026-01-22T18:23:46.492Z",
+  "_lists": [
+    "68bf9e33f871e5004a5eb592",
+    "68bf9e33f871e5004a5eb593"
   ]
+}
+```
+
+### BoardList (from `GET /board/:id/lists`)
+
+```json
+{
+  "_id": "68bf9e33f871e5004a5eb593",
+  "id": "68bf9e33f871e5004a5eb593",
+  "name": "applied",
+  "_board": "68bf9e33f871e5004a5eb58e",
+  "_jobs": ["695ab63801de6a0051c0b03c"],
+  "stageType": "APPLY",
+  "suggestedActivityCategoryNames": ["Follow Up", "Reach Out"],
+  "createdAt": "2025-09-09T03:25:39.779Z",
+  "updatedAt": "2026-03-06T22:36:02.131Z",
+  "__v": 0
 }
 ```
 
@@ -299,31 +299,33 @@ huntr me --json | jq 'keys'
 
 ```json
 {
-  "_id": "507f1f77bcf86cd799439011",
-  "id": "job_001",
-  "title": "Senior Software Engineer",
-  "url": "https://example.com/jobs/engineer",
-  "rootDomain": "example.com",
-  "htmlDescription": "<p>We're looking for...</p>",
-  "_company": "company_1",
-  "_list": "list_2",
+  "_id": "695ab63801de6a0051c0b03c",
+  "id": "695ab63801de6a0051c0b03c",
+  "title": "Software Architect",
+  "url": "https://...",
+  "rootDomain": "icims.com",
+  "htmlDescription": "<p>...</p>",
+  "_company": "58bf62e1e281d9000c2a5cb8",
+  "_list": "68bf9e33f871e5004a5eb593",
   "_board": "68bf9e33f871e5004a5eb58e",
-  "_activities": ["action_1", "action_2", "action_3"],
-  "_notes": ["note_1"],
-  "salary": {
-    "min": 120000,
-    "max": 150000,
-    "currency": "USD"
-  },
+  "_activities": ["695ab63e36ff3901e24c45f0"],
+  "_interviewActivities": [],
+  "_contacts": [],
+  "_todos": [],
+  "_notes": [],
+  "salary": "$161,000.00 - $255,000.00",
   "location": {
-    "address": "San Francisco, CA",
-    "name": "San Francisco",
-    "lat": "37.7749",
-    "lng": "-122.4194"
+    "address": "Germantown, MD, USA",
+    "name": "Germantown",
+    "placeId": "ChIJ...",
+    "url": "https://maps.google.com/?cid=...",
+    "lat": "39.1731621",
+    "lng": "-77.2716502"
   },
-  "createdAt": "2024-01-20T14:15:00Z",
-  "updatedAt": "2024-02-15T10:00:00Z",
-  "lastMovedAt": "2024-02-18T09:30:00Z"
+  "createdAt": "2026-01-04T18:49:28.657Z",
+  "updatedAt": "2026-01-08T21:38:00.838Z",
+  "lastMovedAt": "2026-01-04T18:49:34.240Z",
+  "__v": 0
 }
 ```
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -267,13 +267,19 @@ huntr me --json | jq 'keys'
 
 > **Note on `huntr boards get`:** This command is currently broken in the direct-fetch path and should be considered **non-functional** for JSON output. The CLI command `huntr boards get` calls [`PersonalBoardsApi.get`](../src/api/personal/boards.ts), which requests `/boards/:id`; per [API-ENDPOINTS.md](./API-ENDPOINTS.md), that route returns HTML while the canonical JSON board endpoint is `GET /user/boards`.
 >
-> There is currently no compatibility layer in the codebase that converts that HTML response into JSON. Until this is fixed, do **not** rely on any `huntr boards get` examples in this document for actual usage; instead, use a working command such as:
+> There is currently no compatibility layer in the codebase that converts that HTML response into JSON. Until this is fixed, do **not** rely on any `huntr boards get` examples in this document for actual usage — including the earlier **“Get Entity Types Command”** example that shows:
+>
+> ```bash
+> huntr boards get <board-id> --json | jq 'keys'
+> ```
+>
+> That example is illustrative only and currently non-functional. For real usage, prefer a working command such as:
 >
 > ```bash
 > huntr boards list --json | jq '.[0] | keys'
 > ```
 >
-> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`, at which point this note and workaround can be revised.
+> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`, at which point this note, the earlier example, and this workaround can be revised.
 
 ---
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -267,19 +267,15 @@ huntr me --json | jq 'keys'
 
 > **Note on `huntr boards get`:** This command is currently broken in the direct-fetch path and should be considered **non-functional** for JSON output. The CLI command `huntr boards get` calls [`PersonalBoardsApi.get`](../src/api/personal/boards.ts), which requests `/boards/:id`; per [API-ENDPOINTS.md](./API-ENDPOINTS.md), that route returns HTML while the canonical JSON board endpoint is `GET /user/boards`.
 >
-> There is currently no compatibility layer in the codebase that converts that HTML response into JSON. Until this is fixed, do **not** rely on any `huntr boards get` examples in this document for actual usage — including the earlier **“Get Entity Types Command”** example that shows:
+> There is currently no compatibility layer in the codebase that converts that HTML response into JSON. Until this is fixed, do **not** use `huntr boards get ... --json` for programmatic consumption, even if you see it mentioned in older examples or external snippets.
 >
-> ```bash
-> huntr boards get <board-id> --json | jq 'keys'
-> ```
->
-> That example is illustrative only and currently non-functional. For real usage, prefer a working command such as:
+> For real, working usage when you need board JSON, prefer a command such as:
 >
 > ```bash
 > huntr boards list --json | jq '.[0] | keys'
 > ```
 >
-> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`, at which point this note, the earlier example, and this workaround can be revised.
+> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`. Once that is implemented, this note and any remaining workarounds can be revised to show `huntr boards get` examples again.
 
 ---
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -11,6 +11,7 @@ This document shows the complete structure of each entity type returned by huntr
   id: "<boardId>",
   _id: "<boardId>",
   name: "Job Search 2025",
+  isArchived: false,
   createdAt: "2025-09-09T03:25:39.770Z",
   updatedAt: "2026-01-22T18:23:46.492Z",
   _lists: [
@@ -172,6 +173,8 @@ Returned by `GET /board/:id/lists` as an object map keyed by list ID.
 ### Salary
 
 > **Note:** `salary` is returned as a raw string by the API (e.g. `"$161,000.00 - $255,000.00"`). The TypeScript type `PersonalJob.salary` currently models it as a structured object — this is inaccurate and tracked in [issue #20](https://github.com/mattmck/huntr-cli/issues/20).
+>
+> **Warning:** The CLI currently dereferences `job.salary.min`, `job.salary.max`, and `job.salary.currency` in [`src/cli.ts`](../src/cli.ts), so runtime behavior does not match the API's raw salary string. Until the API/type mismatch is normalized, either parse the raw salary string in the CLI or avoid nested salary property access.
 
 ### Location
 
@@ -265,6 +268,12 @@ huntr activities list <board-id> --format json | jq '.[0] | keys'
 huntr me --json | jq 'keys'
 # Output: ["id", "_id", "email", "givenName", "familyName", ...]
 ```
+
+> **Note on `huntr boards get`:** This command is currently broken in the direct-fetch path. The CLI command `huntr boards get` calls [`PersonalBoardsApi.get`](../src/api/personal/boards.ts), which requests `/boards/:id`; per [API-ENDPOINTS.md](./API-ENDPOINTS.md), that route returns HTML while the canonical JSON board endpoint is `GET /user/boards`.
+>
+> There is currently no compatibility layer in the codebase that converts that HTML response into JSON.
+>
+> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`.
 
 ---
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -272,6 +272,7 @@ huntr me --json | jq 'keys'
 
 ### Board (from `GET /user/boards`)
 
+> Note: The `huntr boards get` CLI command currently hits a legacy, non-JSON route whose output still uses a `lists` field instead of `_lists`. The structure below reflects the canonical API shape returned by `GET /user/boards`; the CLI command will be updated to match this schema.
 > **Note:** The `huntr boards get` CLI command currently hits a legacy, non-JSON route whose output still uses a `lists` field instead of `_lists`. The structure below reflects the canonical API shape returned by `GET /user/boards`; the CLI command will be updated to match this schema.
 
 ```json

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -268,15 +268,15 @@ huntr me --json | jq 'keys'
 
 > **Note on `huntr boards get`:** This command is currently broken in the direct-fetch path and should be considered **non-functional** for JSON output. The CLI command `huntr boards get` calls [`PersonalBoardsApi.get`](../src/api/personal/boards.ts), which requests `/boards/:id`; per [API-ENDPOINTS.md](./API-ENDPOINTS.md), that route returns HTML while the canonical JSON board endpoint is `GET /user/boards`.
 >
-> There is currently no compatibility layer in the codebase that converts that HTML response into JSON. Until this is fixed, do **not** use `huntr boards get ... --json` for programmatic consumption, even if you see it mentioned in older examples or external snippets.
+> There is currently no compatibility layer in the codebase that converts that HTML response into JSON. Until this is fixed, do **not** use `huntr boards get ... --json` for programmatic consumption. This applies to **any** `huntr boards get` usages you might see in this document (for example, in schema/`jq` examples) or in older external snippets — treat those as legacy and replace them with the pattern shown below.
 >
-> For real, working usage when you need board JSON, prefer a command such as:
+> For real, working usage when you need board JSON (including when inspecting schemas with `jq`), prefer a command such as:
 >
 > ```bash
 > huntr boards list --json | jq '.[0] | keys'
 > ```
 >
-> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`. Once that is implemented, this note and any remaining workarounds can be revised to show `huntr boards get` examples again.
+> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`. Once that is implemented, this note and any remaining workarounds can be revised to show `huntr boards get` examples again, and the schema/querying examples in this document can be updated back to `huntr boards get`.
 
 ---
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -265,11 +265,15 @@ huntr me --json | jq 'keys'
 # Output: ["id", "_id", "email", "givenName", "familyName", ...]
 ```
 
-> **Note on `huntr boards get`:** This command is currently broken in the direct-fetch path. The CLI command `huntr boards get` calls [`PersonalBoardsApi.get`](../src/api/personal/boards.ts), which requests `/boards/:id`; per [API-ENDPOINTS.md](./API-ENDPOINTS.md), that route returns HTML while the canonical JSON board endpoint is `GET /user/boards`.
+> **Note on `huntr boards get`:** This command is currently broken in the direct-fetch path and should be considered **non-functional** for JSON output. The CLI command `huntr boards get` calls [`PersonalBoardsApi.get`](../src/api/personal/boards.ts), which requests `/boards/:id`; per [API-ENDPOINTS.md](./API-ENDPOINTS.md), that route returns HTML while the canonical JSON board endpoint is `GET /user/boards`.
 >
-> There is currently no compatibility layer in the codebase that converts that HTML response into JSON.
+> There is currently no compatibility layer in the codebase that converts that HTML response into JSON. Until this is fixed, do **not** rely on any `huntr boards get` examples in this document for actual usage; instead, use a working command such as:
 >
-> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`.
+> ```bash
+> huntr boards list --json | jq '.[0] | keys'
+> ```
+>
+> **TODO:** Update `PersonalBoardsApi.get` so `huntr boards get` resolves boards via `GET /user/boards` (or another confirmed JSON endpoint) and behaves consistently with `API-ENDPOINTS.md`, at which point this note and workaround can be revised.
 
 ---
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -170,7 +170,7 @@ Returned by `GET /board/:id/lists` as an object map keyed by list ID.
 
 > **Note:** `salary` is returned as a raw string by the API (e.g. `"$161,000.00 - $255,000.00"`). The TypeScript type `PersonalJob.salary` currently models it as a structured object — this is inaccurate and tracked in [issue #20](https://github.com/mattmck/huntr-cli/issues/20).
 >
-> **Warning:** The CLI currently dereferences `job.salary.min`, `job.salary.max`, and `job.salary.currency` in [`src/cli.ts`](../src/cli.ts). Because the API returns `salary` as a raw string, this can throw at runtime when that code path executes. Mitigate by changing `PersonalJob.salary` to `string` (or `string | undefined`) and parsing explicitly, or by guarding/null-checking before nested property access until the API/type model is normalized.
+> **Warning:** The CLI currently dereferences `job.salary.min`, `job.salary.max`, and `job.salary.currency` in [`src/cli.ts`](../src/cli.ts) as if `salary` were a structured object. Because the API actually returns `salary` as a raw string, these nested property lookups evaluate to `undefined`, which can cause the salary to be displayed incorrectly (for example, as `N/A`) rather than reflecting the raw value. Mitigate by changing `PersonalJob.salary` to `string` (or `string | undefined`) and updating the CLI to parse and render the string value explicitly, or by aligning the API and type model so that `salary` is genuinely structured.
 
 ### Location
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -126,8 +126,8 @@ This document shows the complete structure of each entity type returned by huntr
 
 > Note: The current TypeScript definitions in `src/types/personal.ts` still model the legacy
 > `lists: BoardList[]` / `order` shape and have not yet been updated to this `_lists`-based
-> API. See the comments in `src/types/personal.ts` and the associated tracking issue for
-> progress on aligning the generated types with this documented response.
+> API. See the `Board.lists` and `BoardList.order` definitions in `src/types/personal.ts` and
+> the associated tracking issue for progress on aligning the generated types with this documented response.
 
 ### BoardList
 

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -224,6 +224,7 @@ Returned by `GET /board/:id/lists` as an object map keyed by list ID.
 | `fullName` | string? | Full name |
 | `auth0IdForMixpanel` | string? | Internal analytics ID |
 
+> Note: The `UserProfile` TypeScript interface in `src/types/personal.ts` is currently out of date with this schema. It still uses legacy `firstName`/`lastName` fields and a required `createdAt`, and does **not** yet include `fullName` or `auth0IdForMixpanel`. Update the interface before relying on these fields in typed code.
 ---
 
 ## Action Types

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -8,14 +8,14 @@ This document shows the complete structure of each entity type returned by huntr
 
 ```typescript
 {
-  id: "68bf9e33f871e5004a5eb58e",
-  _id: "68bf9e33f871e5004a5eb58e",
+  id: "<boardId>",
+  _id: "<boardId>",
   name: "Job Search 2025",
   createdAt: "2025-09-09T03:25:39.770Z",
   updatedAt: "2026-01-22T18:23:46.492Z",
   _lists: [
-    "68bf9e33f871e5004a5eb592",
-    "68bf9e33f871e5004a5eb593"
+    "<listId1>",
+    "<listId2>"
   ]  // bare list IDs — use GET /board/:id/lists to resolve names
 }
 ```
@@ -97,13 +97,13 @@ This document shows the complete structure of each entity type returned by huntr
 
 ```typescript
 {
-  id: "66688215168bb20075e89571",
-  _id: "66688215168bb20075e89571",
+  id: "user_profile_id_1",
+  _id: "user_profile_id_1",
   email: "user@example.com",
-  givenName: "Matthew",
-  familyName: "McKnight",
-  fullName: "Matthew McKnight",
-  auth0IdForMixpanel: "66688215168bb20075e89571"
+  givenName: "Example",
+  familyName: "User",
+  fullName: "Example User",
+  auth0IdForMixpanel: "auth0|example-user-id"
 }
 ```
 
@@ -122,6 +122,11 @@ This document shows the complete structure of each entity type returned by huntr
 | `updatedAt` | ISO 8601 | Last update timestamp |
 | `_lists` | string[] | Array of bare list IDs — resolve via `GET /board/:id/lists` |
 | `isArchived` | boolean | Whether board is archived |
+
+> **Note:** The current TypeScript definitions in `src/types/personal.ts` still model the legacy
+> `lists: BoardList[]` / `order` shape and have not yet been updated to this `_lists`-based
+> API. See the comments in `src/types/personal.ts` and the associated tracking issue for
+> progress on aligning the generated types with this documented response.
 
 ### BoardList
 
@@ -263,17 +268,19 @@ huntr me --json | jq 'keys'
 
 ### Board (from `GET /user/boards`)
 
+> **Note:** The `huntr boards get` CLI command currently hits a legacy, non-JSON route whose output still uses a `lists` field instead of `_lists`. The structure below reflects the canonical API shape returned by `GET /user/boards`; the CLI command will be updated to match this schema.
+
 ```json
 {
-  "id": "68bf9e33f871e5004a5eb58e",
-  "_id": "68bf9e33f871e5004a5eb58e",
+  "id": "<boardId>",
+  "_id": "<boardId>",
   "name": "Job Search 2025",
   "isArchived": false,
   "createdAt": "2025-09-09T03:25:39.770Z",
   "updatedAt": "2026-01-22T18:23:46.492Z",
   "_lists": [
-    "68bf9e33f871e5004a5eb592",
-    "68bf9e33f871e5004a5eb593"
+    "<listId1>",
+    "<listId2>"
   ]
 }
 ```
@@ -282,11 +289,11 @@ huntr me --json | jq 'keys'
 
 ```json
 {
-  "_id": "68bf9e33f871e5004a5eb593",
-  "id": "68bf9e33f871e5004a5eb593",
+  "_id": "<listId>",
+  "id": "<listId>",
   "name": "applied",
-  "_board": "68bf9e33f871e5004a5eb58e",
-  "_jobs": ["695ab63801de6a0051c0b03c"],
+  "_board": "<boardId>",
+  "_jobs": ["<jobId>"],
   "stageType": "APPLY",
   "suggestedActivityCategoryNames": ["Follow Up", "Reach Out"],
   "createdAt": "2025-09-09T03:25:39.779Z",
@@ -299,16 +306,16 @@ huntr me --json | jq 'keys'
 
 ```json
 {
-  "_id": "695ab63801de6a0051c0b03c",
-  "id": "695ab63801de6a0051c0b03c",
+  "_id": "<jobId>",
+  "id": "<jobId>",
   "title": "Software Architect",
   "url": "https://...",
   "rootDomain": "icims.com",
   "htmlDescription": "<p>...</p>",
-  "_company": "58bf62e1e281d9000c2a5cb8",
-  "_list": "68bf9e33f871e5004a5eb593",
-  "_board": "68bf9e33f871e5004a5eb58e",
-  "_activities": ["695ab63e36ff3901e24c45f0"],
+  "_company": "<companyId>",
+  "_list": "<listId>",
+  "_board": "<boardId>",
+  "_activities": ["<activityId>"],
   "_interviewActivities": [],
   "_contacts": [],
   "_todos": [],
@@ -342,7 +349,7 @@ huntr me --json | jq 'keys'
   "data": {
     "_job": "job_001",
     "_company": "company_1",
-    "_board": "68bf9e33f871e5004a5eb58e",
+    "_board": "<boardId>",
     "_fromList": "list_1",
     "_toList": "list_2",
     "job": {

--- a/docs/ENTITY-TYPES.md
+++ b/docs/ENTITY-TYPES.md
@@ -17,7 +17,7 @@ This document shows the complete structure of each entity type returned by huntr
   _lists: [
     "<listId1>",
     "<listId2>"
-  ]  // bare list IDs — use GET /board/:id/lists to resolve names
+  ]  // bare list IDs — use GET /board/:boardId/lists to resolve names
 }
 ```
 


### PR DESCRIPTION
## Summary

Documents real Huntr API endpoint shapes discovered during investigation of issue #20.

## Changes

- **New:** `docs/API-ENDPOINTS.md` — complete reference for all working endpoints with real response shapes, plus a table of non-working routes (HTML-returning paths)
- **Updated:** `docs/ENTITY-TYPES.md` — corrected three inaccuracies:
  - `Board._lists` is `string[]` (bare IDs), not an array of `BoardList` objects
  - `BoardList` has `stageType`, `_jobs`, `suggestedActivityCategoryNames` — the `order` field doesn't exist in the real API
  - `salary` on `PersonalJob` is a raw string (e.g. `",000.00 - ,000.00"`), not `{min, max, currency}`

## Related

Closes none — documentation companion to #20 (code fix tracked separately).

---

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved docs navigation and descriptions for clarity.
  * Added a comprehensive API endpoints guide (authentication, paths, responses, known quirks).
  * Updated entity docs and examples to reflect actual API shapes: boards now reference lists by ID, lists and jobs show flattened/ID-based structures, salary shown as raw string, and user profile fields updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->